### PR TITLE
fix: missing mounting of rubygems in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,5 +27,7 @@ build:
     when:
       event: push
       branch: master
+    volumes:
+      - /home/data/drone/rubygems:/root/.gem
     commands:
       - release-gem --public


### PR DESCRIPTION
Забыл строчку добавить, из-за этого не релизнулся
https://github.com/abak-press/string_tools/blame/master/.drone.yml#L30